### PR TITLE
feat: Implement Issue #11 - Implement FFmpeg Utility for Post-Processing Conversion

### DIFF
--- a/src/main/kotlin/com/archon/util/FFmpegUtility.kt
+++ b/src/main/kotlin/com/archon/util/FFmpegUtility.kt
@@ -1,0 +1,135 @@
+package com.archon.util
+
+import java.io.BufferedReader
+import java.io.File
+import java.io.InputStreamReader
+import java.util.concurrent.TimeUnit
+
+/**
+ * Custom exception for FFmpeg operational errors.
+ */
+class FFmpegExecutionException(message: String, cause: Throwable? = null) : RuntimeException(message, cause)
+
+interface CommandExecutor {
+    fun execute(command: List<String>): ExecutionResult
+}
+
+data class ExecutionResult(
+    val exitCode: Int,
+    val output: String
+)
+
+/**
+ * Executes a system command using ProcessBuilder.
+ * @param timeoutSeconds Maximum time allowed for command execution.
+ */
+class RealCommandExecutor(private val timeoutSeconds: Long = 60L) : CommandExecutor {
+    override fun execute(command: List<String>): ExecutionResult {
+        
+        // Log the command structure (replace with proper logging framework in production)
+        println("Executing command: ${command.joinToString(" ")}") 
+
+        try {
+            val process = ProcessBuilder(command)
+                .redirectErrorStream(true) // Merge stderr into stdout
+                .start()
+
+            val finished = process.waitFor(timeoutSeconds, TimeUnit.SECONDS)
+
+            val output = BufferedReader(InputStreamReader(process.inputStream)).use { it.readText() }
+
+            if (!finished) {
+                process.destroyForcibly()
+                throw FFmpegExecutionException("Command timed out after $timeoutSeconds seconds.")
+            }
+
+            val exitCode = process.exitValue()
+            
+            return ExecutionResult(exitCode, output)
+        } catch (e: Exception) {
+            throw FFmpegExecutionException("Error executing process: ${e.message}", e)
+        }
+    }
+}
+
+/**
+ * Utility class for safely wrapping FFmpeg command execution for post-processing tasks.
+ * Relies on an injectable CommandExecutor for process execution.
+ * Assumes 'ffmpeg' is accessible in the execution environment.
+ */
+class FFmpegUtility(private val executor: CommandExecutor) {
+
+    private val FFMPEG_COMMAND = "ffmpeg"
+
+    /**
+     * Executes a full command sequence and validates the exit code.
+     * Arguments must be provided as a list of strings to prevent shell injection.
+     * @param args The list of arguments following 'ffmpeg'.
+     * @throws FFmpegExecutionException if the command fails or times out.
+     */
+    fun runFFmpeg(args: List<String>): String {
+        val fullCommand = mutableListOf(FFMPEG_COMMAND).apply { addAll(args) }
+        
+        val result = executor.execute(fullCommand)
+
+        if (result.exitCode != 0) {
+            throw FFmpegExecutionException("FFmpeg command failed with exit code ${result.exitCode}. Output:\n${result.output}")
+        }
+        return result.output
+    }
+
+    /**
+     * Converts a source image file to a specified target format and compression settings.
+     *
+     * @param sourceFile The input file path.
+     * @param targetFile The output file path.
+     * @param extension The target file extension (e.g., "png", "webp", "jpg"). Case-insensitive.
+     * @param quality Optional quality setting for lossy formats (1-100). Ignored if null or for lossless formats.
+     */
+    fun convertImage(
+        sourceFile: File,
+        targetFile: File,
+        extension: String,
+        quality: Int? = null
+    ) {
+        if (!sourceFile.exists()) {
+            throw IllegalArgumentException("Source file does not exist: ${sourceFile.absolutePath}")
+        }
+
+        // Use absolute paths
+        val args = mutableListOf(
+            "-i", sourceFile.absolutePath,
+            "-y" // Overwrite output files without asking
+        )
+
+        val normalizedExtension = extension.toLowerCase()
+
+        when (normalizedExtension) {
+            "png" -> {
+                // PNG compression level (1-9). Quality mapping to compression.
+                val compressionLevel = quality?.let { (it / 10).coerceIn(1, 9) } ?: 6
+                args.addAll(listOf("-compression_level", compressionLevel.toString()))
+            }
+            "webp" -> {
+                // WEBP standard quality (0-100)
+                quality?.let {
+                    args.addAll(listOf("-q:v", it.coerceIn(0, 100).toString()))
+                }
+            }
+            "jpeg", "jpg" -> {
+                // JPEG quality (1-100)
+                quality?.let {
+                    args.addAll(listOf("-q:v", it.coerceIn(1, 100).toString()))
+                }
+            }
+            else -> {
+                // Default handling for other extensions (e.g., tiff, bmp) using standard ffmpeg defaults
+            }
+        }
+
+        // Output file path is the last argument defining the container format
+        args.add(targetFile.absolutePath)
+
+        runFFmpeg(args)
+    }
+}

--- a/src/test/kotlin/com/archon/util/FFmpegUtilityTest.kt
+++ b/src/test/kotlin/com/archon/util/FFmpegUtilityTest.kt
@@ -1,0 +1,167 @@
+package com.archon.util
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.nio.file.Path
+
+/**
+ * Mock executor to capture commands and simulate results/failures without requiring actual FFmpeg installation.
+ */
+class MockCommandExecutor(
+    var mockResult: ExecutionResult = ExecutionResult(0, "Mock Success Output"),
+    var capturedCommand: List<String>? = null,
+    var shouldThrow: Boolean = false
+) : CommandExecutor {
+    override fun execute(command: List<String>): ExecutionResult {
+        capturedCommand = command
+        if (shouldThrow) {
+            // Simulate failure during process startup/timeout
+            throw FFmpegExecutionException("Simulated execution failure")
+        }
+        return mockResult
+    }
+}
+
+class FFmpegUtilityTest {
+
+    private lateinit var mockExecutor: MockCommandExecutor
+    private lateinit var ffMpegUtility: FFmpegUtility
+
+    @TempDir
+    lateinit var tempDir: Path
+
+    private lateinit var inputFile: File
+
+    @BeforeEach
+    fun setUp() {
+        mockExecutor = MockCommandExecutor()
+        ffMpegUtility = FFmpegUtility(mockExecutor)
+
+        // Create a dummy input file for existence checks
+        inputFile = tempDir.resolve("input.tiff").toFile()
+        inputFile.createNewFile()
+    }
+
+    // --- Tests for runFFmpeg execution safety and error handling ---
+
+    @Test
+    fun `runFFmpeg executes command correctly and returns output`() {
+        val testArgs = listOf("-version")
+        val output = ffMpegUtility.runFFmpeg(testArgs)
+
+        assertTrue(mockExecutor.capturedCommand!!.contains("ffmpeg"))
+        assertTrue(mockExecutor.capturedCommand!!.contains("-version"))
+        assertEquals("Mock Success Output", output)
+    }
+
+    @Test
+    fun `runFFmpeg throws FFmpegExecutionException on non-zero exit code`() {
+        mockExecutor.mockResult = ExecutionResult(1, "Error details")
+
+        val exception = assertThrows<FFmpegExecutionException> {
+            ffMpegUtility.runFFmpeg(listOf("-i", "bad_path"))
+        }
+        assertTrue(exception.message!!.contains("failed with exit code 1"))
+    }
+
+    @Test
+    fun `runFFmpeg throws FFmpegExecutionException on underlying execution failure`() {
+        mockExecutor.shouldThrow = true
+        assertThrows<FFmpegExecutionException> {
+            ffMpegUtility.runFFmpeg(listOf())
+        }
+    }
+
+    // --- Tests for convertImage command generation ---
+
+    @Test
+    fun `convertImage throws IllegalArgumentException if source file does not exist`() {
+        val nonExistentFile = tempDir.resolve("non_existent.jpg").toFile()
+        val outputFile = tempDir.resolve("output.webp").toFile()
+
+        assertThrows<IllegalArgumentException> {
+            ffMpegUtility.convertImage(nonExistentFile, outputFile, "webp")
+        }
+    }
+
+    @Test
+    fun `convertImage generates correct command for WEBP conversion with quality 80`() {
+        val targetFileWebp = tempDir.resolve("output.webp").toFile()
+        ffMpegUtility.convertImage(inputFile, targetFileWebp, "WEBP", 80)
+
+        val command = mockExecutor.capturedCommand!!
+        
+        // Command structure verification
+        assertTrue(command.contains(inputFile.absolutePath))
+        assertTrue(command.contains(targetFileWebp.absolutePath))
+        assertTrue(command.contains("-q:v"))
+        assertTrue(command.contains("80"))
+    }
+
+    @Test
+    fun `convertImage generates correct command for PNG conversion with high quality`() {
+        val targetFilePng = tempDir.resolve("output.png").toFile()
+        ffMpegUtility.convertImage(inputFile, targetFilePng, "PNG", 95) // Quality 95 maps to compression level 9
+
+        val command = mockExecutor.capturedCommand!!
+        
+        // PNG uses -compression_level
+        assertTrue(command.contains("-compression_level"))
+        assertTrue(command.contains("9"))
+    }
+
+    @Test
+    fun `convertImage uses default compression level for PNG if quality is null`() {
+        val targetFilePng = tempDir.resolve("output.png").toFile()
+        ffMpegUtility.convertImage(inputFile, targetFilePng, "PNG", null) 
+
+        val command = mockExecutor.capturedCommand!!
+        
+        // Default level is 6
+        assertTrue(command.contains("-compression_level"))
+        assertTrue(command.contains("6"))
+    }
+
+    @Test
+    fun `convertImage uses default quality settings for JPG if quality is null`() {
+        val targetFileJpg = tempDir.resolve("output.jpg").toFile()
+        ffMpegUtility.convertImage(inputFile, targetFileJpg, "JPG", null)
+
+        val command = mockExecutor.capturedCommand!!
+        
+        // Should not contain explicit quality flags (-q:v), relying on ffmpeg default
+        assertFalse(command.contains("-q:v"))
+        
+        assertTrue(command.contains(inputFile.absolutePath))
+        assertTrue(command.contains(targetFileJpg.absolutePath))
+    }
+
+    @Test
+    fun `convertImage handles mixed case extensions correctly`() {
+        val targetFileWebp = tempDir.resolve("output.WEBP").toFile()
+        ffMpegUtility.convertImage(inputFile, targetFileWebp, "wEbP", 50)
+
+        val command = mockExecutor.capturedCommand!!
+        
+        assertTrue(command.contains("-q:v"))
+        assertTrue(command.contains("50"))
+    }
+
+    @Test
+    fun `convertImage handles non-specialized extensions`() {
+        val targetFileTiff = tempDir.resolve("output.tiff").toFile()
+        ffMpegUtility.convertImage(inputFile, targetFileTiff, "TIFF", 50)
+
+        val command = mockExecutor.capturedCommand!!
+        
+        // Should not contain quality flags
+        assertFalse(command.contains("-q:v"))
+        assertFalse(command.contains("-compression_level"))
+        
+        assertTrue(command.contains(inputFile.absolutePath))
+        assertTrue(command.contains(targetFileTiff.absolutePath))
+    }
+}


### PR DESCRIPTION
Closes #11

Automated implementation by Archon.

Changes:
- Added/Updated src/main/kotlin/com/archon/util/FFmpegUtility.kt
- Added/Updated src/test/kotlin/com/archon/util/FFmpegUtilityTest.kt